### PR TITLE
v4.1.0 — deploy workflow, version command, and versioned update-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,15 @@ curl -fsSL https://raw.githubusercontent.com/thisisgain/Mimir/main/install.sh | 
 
 This downloads `setup.sh` to `/usr/local/bin/mimir` and prompts for your password (sudo required to write there). You only need to do this once per machine.
 
-To update to the latest version, run the same command again.
+### Updating
+
+To pull in the latest changes to Mimir:
+
+```bash
+mimir update-cli
+```
+
+This re-downloads `setup.sh` from GitHub and reinstalls it — equivalent to running the curl command above again.
 
 ---
 
@@ -62,10 +70,11 @@ The interactive wizard walks through the following steps in order:
 3. **Site configuration** — URL, title, admin credentials
 4. **WordPress core** — downloads core (`en_GB`), generates `wp-config.php`, creates the database, runs the install
 5. **Theme setup** — clones Erebus as the parent theme, scaffolds a child theme with the correct `Template:` header
-6. **Git initialisation** — writes a `.gitignore`, makes the initial commit on `main`, optionally sets a remote and pushes
-7. *(Placeholder)* Plugin installation
-8. *(Placeholder)* Optional WP settings configuration
-9. *(Placeholder)* Front-end build dependency installation
+6. **Deploy workflow** — copies `deploy.yml` from the Mimir repo into `.github/workflows/`
+7. **Git initialisation** — writes a `.gitignore`, makes the initial commit on `main`, optionally sets a remote and pushes
+8. *(Placeholder)* Plugin installation
+9. *(Placeholder)* Optional WP settings configuration
+10. *(Placeholder)* Front-end build dependency installation
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -30,15 +30,27 @@ curl -fsSL https://raw.githubusercontent.com/thisisgain/Mimir/main/install.sh | 
 
 This downloads `setup.sh` to `/usr/local/bin/mimir` and prompts for your password (sudo required to write there). You only need to do this once per machine.
 
+To install a specific version:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/thisisgain/Mimir/main/install.sh | bash -s -- --version=4.0.0
+```
+
 ### Updating
 
-To pull in the latest changes to Mimir:
+To pull in the latest release:
 
 ```bash
 mimir update-cli
 ```
 
-This re-downloads `setup.sh` from GitHub and reinstalls it — equivalent to running the curl command above again.
+To update to a specific version:
+
+```bash
+mimir update-cli --version=4.1.0
+```
+
+Both commands fetch `setup.sh` from the corresponding [GitHub release tag](https://github.com/thisisgain/Mimir/releases) and reinstall it to `/usr/local/bin/mimir`.
 
 ---
 
@@ -49,6 +61,12 @@ From an **empty directory** that will become your project root:
 ```bash
 mkdir my-project && cd my-project
 mimir
+```
+
+To check the currently installed version:
+
+```bash
+mimir version
 ```
 
 ### Local development (without global install)

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The following are planned additions. Each has a placeholder stub in `setup.sh` m
 
 - [ ] **Settings configuration** — `setup_config()` is a stub. Implement optional WordPress settings (permalink structure, timezone, default post/comment settings, etc.) using `wp option update`.
 
-- [ ] **Build dependencies** — `setup_build()` is a stub. Once the Erebus build tooling is confirmed, implement `npm install` (and an optional initial build run) in both the parent and child theme directories.
+- [ ] **Build dependencies** — `setup_build()` is a stub. Once the Erebus build tooling is confirmed, implement `yarn install` (and an optional initial build run) in both the parent and child theme directories.
 
 ---
 

--- a/deploy.yml
+++ b/deploy.yml
@@ -1,0 +1,63 @@
+name: Deploy to WP Engine
+
+on:
+    push:
+        branches:
+            - develop
+            - uat
+            - master
+            - main
+
+jobs:
+    build-and-deploy:
+        runs-on: ubuntu-latest
+        environment: ${{ (github.ref_name == 'master' || github.ref_name == 'main') && 'production' || github.ref_name }}
+
+        env:
+            THEME_DIR: ${{ vars.THEME_DIR }}
+            WPE_ENV: ${{ vars.WPE_ENV }}
+            NODE_VERSION: ${{ vars.NODE_VERSION }}
+            PHP_VERSION: ${{ vars.PHP_VERSION }}
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            # -------- Frontend (Yarn) in theme folder --------
+            - name: Use Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: ${{ env.NODE_VERSION }}
+                  cache: 'yarn'
+                  cache-dependency-path: ${{ env.THEME_DIR }}/yarn.lock
+
+            - name: Install frontend deps (theme)
+              working-directory: ${{ env.THEME_DIR }}
+              run: yarn install --frozen-lockfile
+
+            - name: Build frontend (theme)
+              working-directory: ${{ env.THEME_DIR }}
+              run: yarn build:prod
+
+            - name: Remove frontend deps before deploy
+              working-directory: ${{ env.THEME_DIR }}
+              run: rm -rf node_modules
+
+            # -------- Backend (Composer) in repo root --------
+            - name: Setup PHP with Composer
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: ${{ env.PHP_VERSION }}
+                  tools: composer:v2
+                  coverage: none
+                  extensions: zip
+            - name: Install Composer deps (no dev, optimized)
+              working-directory: ${{ env.THEME_DIR }}
+              run: composer install --no-dev -o --no-scripts
+
+            # -------- Deploy full repo to WP Engine --------
+            - name: Deploy to WP Engine
+              uses: wpengine/github-action-wpe-site-deploy@v3
+              with:
+                  WPE_SSHG_KEY_PRIVATE: ${{ secrets.WPE_SSHG_KEY_PRIVATE }}
+                  WPE_ENV: ${{ env.WPE_ENV }}

--- a/install.sh
+++ b/install.sh
@@ -4,13 +4,15 @@
 # Installs the `mimir` command to /usr/local/bin so it can be run from
 # any directory. Requires sudo.
 #
-# Usage: curl -fsSL https://raw.githubusercontent.com/thisisgain/Mimir/main/install.sh | bash
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/thisisgain/Mimir/main/install.sh | bash
+#   curl -fsSL https://raw.githubusercontent.com/thisisgain/Mimir/main/install.sh | bash -s -- --version=4.0.0
 
 set -eo pipefail
 
+MIMIR_REPO="thisisgain/Mimir"
 INSTALL_DIR="/usr/local/bin"
 INSTALL_PATH="${INSTALL_DIR}/mimir"
-SCRIPT_URL="https://raw.githubusercontent.com/thisisgain/Mimir/main/setup.sh"
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -22,14 +24,42 @@ info()    { echo -e "  ${BLUE}→ $1${RESET}"; }
 success() { echo -e "  ${GREEN}✓ $1${RESET}"; }
 error()   { echo -e "\n  ${RED}${BOLD}✗ $1${RESET}" >&2; exit 1; }
 
+# Parse --version=X.Y.Z or --version X.Y.Z
+VERSION_INPUT=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version=*) VERSION_INPUT="${1#--version=}"; shift ;;
+    --version)   VERSION_INPUT="${2:-}"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+
 echo ""
 echo -e "${BLUE}${BOLD}  Installing Mimir...${RESET}"
 echo ""
 
-# Download the setup script
+# Resolve version tag
+if [[ -n "$VERSION_INPUT" ]]; then
+  # Normalise: strip leading 'v', then re-add
+  VERSION_TAG="v${VERSION_INPUT#v}"
+  info "Installing Mimir ${VERSION_TAG}..."
+else
+  info "Fetching latest Mimir release..."
+  VERSION_TAG=$(curl -fsSL "https://api.github.com/repos/${MIMIR_REPO}/releases/latest" \
+    | grep '"tag_name"' \
+    | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/') \
+    || error "Could not reach GitHub — check your internet connection."
+  [[ -z "$VERSION_TAG" ]] && error "Could not determine the latest Mimir release."
+  info "Latest release: ${VERSION_TAG}"
+fi
+
+SCRIPT_URL="https://raw.githubusercontent.com/${MIMIR_REPO}/${VERSION_TAG}/setup.sh"
+
+# Download
 info "Downloading setup script..."
 TMP=$(mktemp)
-curl -fsSL "$SCRIPT_URL" -o "$TMP" || error "Failed to download setup script from ${SCRIPT_URL}"
+curl -fsSL "$SCRIPT_URL" -o "$TMP" \
+  || error "Failed to download Mimir ${VERSION_TAG}. Check the version exists: https://github.com/${MIMIR_REPO}/releases"
 
 chmod +x "$TMP"
 
@@ -38,7 +68,8 @@ info "Installing to ${INSTALL_PATH} (may prompt for your password)..."
 sudo mv "$TMP" "$INSTALL_PATH"
 sudo chmod +x "$INSTALL_PATH"
 
-success "mimir installed to ${INSTALL_PATH}"
+success "Mimir ${VERSION_TAG} installed to ${INSTALL_PATH}"
 echo ""
 echo -e "  Run ${BOLD}mimir${RESET} from any new empty project directory to get started."
+echo -e "  Run ${BOLD}mimir version${RESET} to confirm the installed version."
 echo ""

--- a/setup.sh
+++ b/setup.sh
@@ -12,6 +12,9 @@ trap 'echo -e "\n  \033[0;31m\033[1m✗ Setup failed on line ${LINENO}. See outp
 
 # ─── Config ──────────────────────────────────────────────────────────────────
 
+readonly MIMIR_VERSION="4.1.0"
+readonly MIMIR_REPO="thisisgain/Mimir"
+
 readonly EREBUS_REPO="git@github.com:thisisgain/Erebus.git"
 readonly EREBUS_THEME_DIR="wp-content/themes/erebus"
 readonly DEFAULT_ADMIN_EMAIL="harry.finn@thisisgain.com"
@@ -484,27 +487,73 @@ print_summary() {
   echo ""
 }
 
+# ─── Version helpers ─────────────────────────────────────────────────────────
+
+# Normalise a version string to vX.Y.Z — strips a leading 'v' then re-adds it.
+normalise_version() {
+  local v="${1#v}"
+  echo "v${v}"
+}
+
+# Fetch the latest release tag from GitHub.
+latest_release_tag() {
+  local tag
+  tag=$(curl -fsSL "https://api.github.com/repos/${MIMIR_REPO}/releases/latest" \
+    | grep '"tag_name"' \
+    | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/') \
+    || error "Could not reach GitHub — check your internet connection."
+  [[ -z "$tag" ]] && error "Could not determine the latest Mimir release."
+  echo "$tag"
+}
+
 # ─── Update CLI ──────────────────────────────────────────────────────────────
 
 update_cli() {
   local install_path="/usr/local/bin/mimir"
-  local script_url="https://raw.githubusercontent.com/thisisgain/Mimir/main/setup.sh"
+  local version_input=""
+
+  # Parse --version=X.Y.Z or --version X.Y.Z
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --version=*) version_input="${1#--version=}"; shift ;;
+      --version)   version_input="${2:-}"; shift 2 ;;
+      *) shift ;;
+    esac
+  done
 
   echo ""
   echo -e "${BLUE}${BOLD}  Updating Mimir CLI...${RESET}" >&2
   echo ""
 
+  local version_tag
+  if [[ -n "$version_input" ]]; then
+    version_tag=$(normalise_version "$version_input")
+    info "Installing Mimir ${version_tag}..."
+  else
+    info "Fetching latest Mimir release..."
+    version_tag=$(latest_release_tag)
+    info "Latest release: ${version_tag}"
+  fi
+
+  local script_url="https://raw.githubusercontent.com/${MIMIR_REPO}/${version_tag}/setup.sh"
   local tmp
   tmp=$(mktemp)
-  info "Downloading latest setup script..."
+  info "Downloading ${script_url}..."
   curl -fsSL "$script_url" -o "$tmp" \
-    || error "Failed to download from ${script_url}"
+    || error "Failed to download Mimir ${version_tag}. Check the version exists: https://github.com/${MIMIR_REPO}/releases"
   chmod +x "$tmp"
   info "Installing to ${install_path} (may prompt for your password)..."
   sudo mv "$tmp" "$install_path"
   sudo chmod +x "$install_path"
-  success "Mimir updated successfully"
+  success "Mimir updated to ${version_tag}"
   echo ""
+  exit 0
+}
+
+# ─── Version ─────────────────────────────────────────────────────────────────
+
+cmd_version() {
+  echo "  Mimir v${MIMIR_VERSION}"
   exit 0
 }
 
@@ -513,12 +562,14 @@ update_cli() {
 usage() {
   cat << USAGE
 
-  Mimir v4 — GAIN WordPress Project Setup
+  Mimir v${MIMIR_VERSION} — GAIN WordPress Project Setup
 
   Usage:
-    mimir                 Run the interactive setup wizard
-    mimir update-cli      Update mimir to the latest version
-    mimir --help          Show this help text
+    mimir                              Run the interactive setup wizard
+    mimir version                      Print the installed Mimir version
+    mimir update-cli                   Update to the latest release
+    mimir update-cli --version=4.1.0   Update to a specific version
+    mimir --help                       Show this help text
 
   Prerequisites:
     - WP-CLI  (https://wp-cli.org)
@@ -537,7 +588,8 @@ USAGE
 main() {
   case "${1:-}" in
     --help|-h)   usage ;;
-    update-cli)  update_cli ;;
+    version)     cmd_version ;;
+    update-cli)  update_cli "${@:2}" ;;
   esac
 
   banner

--- a/setup.sh
+++ b/setup.sh
@@ -339,7 +339,33 @@ PHP
   fi
 }
 
-# ─── Step 4: Plugins (placeholder) ───────────────────────────────────────────
+# ─── Step 4: GitHub Actions deploy workflow ──────────────────────────────────
+
+setup_deploy() {
+  step "GitHub Actions deploy workflow"
+
+  local workflows_dir=".github/workflows"
+  local deploy_dest="${workflows_dir}/deploy.yml"
+  local deploy_src="https://raw.githubusercontent.com/thisisgain/Mimir/main/deploy.yml"
+
+  if [[ -f "$deploy_dest" ]]; then
+    success "Deploy workflow already exists, skipping"
+    return
+  fi
+
+  mkdir -p "$workflows_dir"
+  curl -fsSL "$deploy_src" -o "$deploy_dest" \
+    || error "Failed to download deploy workflow from ${deploy_src}"
+
+  success "Deploy workflow written to ${deploy_dest}"
+  info "Configure the following in your GitHub repo settings before pushing:"
+  echo "" >&2
+  echo -e "    ${BOLD}Variables:${RESET}  THEME_DIR, WPE_ENV, NODE_VERSION, PHP_VERSION" >&2
+  echo -e "    ${BOLD}Secret:${RESET}     WPE_SSHG_KEY_PRIVATE" >&2
+  echo "" >&2
+}
+
+# ─── Step 5: Plugins (placeholder) ───────────────────────────────────────────
 
 setup_plugins() {
   # TODO: Install default plugin set.
@@ -349,7 +375,7 @@ setup_plugins() {
   :
 }
 
-# ─── Step 5: Optional config (placeholder) ───────────────────────────────────
+# ─── Step 6: Optional config (placeholder) ───────────────────────────────────
 
 setup_config() {
   # TODO: Apply optional WordPress settings (permalink structure, timezone,
@@ -358,7 +384,7 @@ setup_config() {
   :
 }
 
-# ─── Step 6: Build dependencies (placeholder) ────────────────────────────────
+# ─── Step 7: Build dependencies (placeholder) ────────────────────────────────
 
 setup_build() {
   # TODO: Install front-end build dependencies once build tooling in Erebus
@@ -367,7 +393,7 @@ setup_build() {
   :
 }
 
-# ─── Step 7: Git initialisation ──────────────────────────────────────────────
+# ─── Step 8: Git initialisation ──────────────────────────────────────────────
 
 setup_git() {
   step "Git repository setup"
@@ -458,6 +484,30 @@ print_summary() {
   echo ""
 }
 
+# ─── Update CLI ──────────────────────────────────────────────────────────────
+
+update_cli() {
+  local install_path="/usr/local/bin/mimir"
+  local script_url="https://raw.githubusercontent.com/thisisgain/Mimir/main/setup.sh"
+
+  echo ""
+  echo -e "${BLUE}${BOLD}  Updating Mimir CLI...${RESET}" >&2
+  echo ""
+
+  local tmp
+  tmp=$(mktemp)
+  info "Downloading latest setup script..."
+  curl -fsSL "$script_url" -o "$tmp" \
+    || error "Failed to download from ${script_url}"
+  chmod +x "$tmp"
+  info "Installing to ${install_path} (may prompt for your password)..."
+  sudo mv "$tmp" "$install_path"
+  sudo chmod +x "$install_path"
+  success "Mimir updated successfully"
+  echo ""
+  exit 0
+}
+
 # ─── Usage ───────────────────────────────────────────────────────────────────
 
 usage() {
@@ -466,8 +516,9 @@ usage() {
   Mimir v4 — GAIN WordPress Project Setup
 
   Usage:
-    ./setup.sh          Run the interactive setup wizard
-    ./setup.sh --help   Show this help text
+    mimir                 Run the interactive setup wizard
+    mimir update-cli      Update mimir to the latest version
+    mimir --help          Show this help text
 
   Prerequisites:
     - WP-CLI  (https://wp-cli.org)
@@ -484,12 +535,16 @@ USAGE
 # ─── Main ────────────────────────────────────────────────────────────────────
 
 main() {
-  [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]] && usage
+  case "${1:-}" in
+    --help|-h)   usage ;;
+    update-cli)  update_cli ;;
+  esac
 
   banner
   check_requirements
   setup_core
   setup_themes
+  setup_deploy
   setup_plugins
   setup_config
   setup_build


### PR DESCRIPTION
## Summary

- **Deploy workflow** — `setup_deploy()` added as step 4 of the setup wizard; fetches `deploy.yml` from this repo into `.github/workflows/` of the new project, with a reminder to configure the required GitHub Actions variables and secret before pushing
- **`mimir version`** — new subcommand that prints the currently installed Mimir version (`MIMIR_VERSION` is now stored in the script as `4.1.0`)
- **Versioned `update-cli`** — `mimir update-cli` now fetches the latest GitHub release tag via the API instead of pulling from `main`; supports `--version=X.Y.Z` to pin a specific release
- **`install.sh`** — same treatment; defaults to latest release, supports `bash -s -- --version=X.Y.Z`

## Test plan

- [ ] `mimir version` → prints `Mimir v4.1.0`
- [ ] `mimir --help` → shows updated usage including `version` and `update-cli --version`
- [ ] `mimir update-cli --version=4.0.0` → downloads and installs v4.0.0 (then re-symlink with `sudo ln -sf ~/Development/Mimir/setup.sh /usr/local/bin/mimir`)
- [ ] `mimir update-cli` (no flag) → resolves and installs latest release tag
- [ ] Fresh install: `curl -fsSL https://raw.githubusercontent.com/thisisgain/Mimir/main/install.sh | bash` → installs latest tagged release
- [ ] Run full `mimir` setup on a new empty project directory — confirm deploy workflow appears at `.github/workflows/deploy.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)